### PR TITLE
Further bug patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,16 @@ This is necessary to the Save to Device feature only. The plugin will _temporari
 
 The following open-source projects helped to make Codify possible!
 
-- [highlighter](https://github.com/boatbomber/Highlighter/tree/v0.4.5) by @boatbomber
-- [studio-plugin](https://github.com/csqrl/studio-plugin/tree/1.0.1) by @csqrl
-- [studio-theme](https://github.com/csqrl/studio-theme/tree/1.0.2) by @csqrl
-- [roblox-lua-promise](https://github.com/evaera/roblox-lua-promise/tree/v3.2.1) by @evaera
-- [llama](https://github.com/freddylist/llama/tree/v1.1.1) by @freddylist
-- [roact-hooks](https://github.com/Kampfkarren/roact-hooks/tree/0.3.0) by @kampfkarren
-- [roact-router](https://github.com/Reselim/roact-router/tree/v1.0.0) by @reselim
-- [roact](https://github.com/Roblox/roact/tree/v1.4.2) by @roblox
-- [rodux](https://github.com/Roblox/rodux/tree/v3.0.0) by @roblox
-- [rodux-hooks](https://github.com/SolarHorizon/rodux-hooks/tree/0.2.1) by @solarhorizon
+- [highlighter](https://github.com/boatbomber/highlighter) by @boatbomber
+- [studio-plugin](https://github.com/csqrl/studio-plugin) by @csqrl
+- [studio-theme](https://github.com/csqrl/studio-theme) by @csqrl
+- [roblox-lua-promise](https://github.com/evaera/roblox-lua-promise) by @evaera
+- [roact-hooks](https://github.com/kampfkarren/roact-hooks) by @kampfkarren
+- [roact-router](https://github.com/reselim/roact-router) by @reselim
+- [roact](https://github.com/roblox/roact) by @roblox
+- [rodux](https://github.com/roblox/rodux) by @roblox
+- [rodux-hooks](https://github.com/solarhorizon/rodux-hooks) by @solarhorizon
+- [sift](https://github.com/csqrl/sift) by @csqrl
 
 ## Disclaimer
 

--- a/src/Components/Alert.lua
+++ b/src/Components/Alert.lua
@@ -3,7 +3,7 @@ local Packages = script.Parent.Parent.Packages
 local Roact = require(Packages.Roact)
 local Hooks = require(Packages.Hooks)
 local StudioTheme = require(Packages.StudioTheme)
-local Llama = require(Packages.Llama)
+local Sift = require(Packages.Sift)
 
 local Icon = require(script.Parent.Icon)
 local Text = require(script.Parent.Text)
@@ -47,7 +47,7 @@ local function Alert(props: AlertProps, hooks)
 			return false
 		end
 
-		return Llama.Dictionary.count(props[Roact.Children]) > 0
+		return Sift.Dictionary.count(props[Roact.Children]) > 0
 	end, { props[Roact.Children] })
 
 	return e("Frame", {

--- a/src/Components/Dropdown/init.lua
+++ b/src/Components/Dropdown/init.lua
@@ -2,7 +2,7 @@ local Packages = script.Parent.Parent.Packages
 
 local Roact = require(Packages.Roact)
 local Hooks = require(Packages.Hooks)
-local Llama = require(Packages.Llama)
+local Sift = require(Packages.Sift)
 
 local DropdownButton = require(script.Button)
 local PopoverShield = require(script.Shield)
@@ -47,7 +47,7 @@ local function Dropdown(props: DropdownProps, hooks)
 			return labelA < labelB
 		end)
 
-		return Llama.List.map(props.options, function(option: DropdownOption, index: number)
+		return Sift.Array.map(props.options, function(option: DropdownOption, index: number)
 			return e(OptionButton, {
 				icon = option.icon,
 				iconColour = option.iconColour,

--- a/src/Components/FrameworkSelect.lua
+++ b/src/Components/FrameworkSelect.lua
@@ -3,7 +3,7 @@ local Plugin = script.Parent.Parent
 local RoduxHooks = require(Plugin.Packages.RoduxHooks)
 local Roact = require(Plugin.Packages.Roact)
 local Hooks = require(Plugin.Packages.Hooks)
-local Llama = require(Plugin.Packages.Llama)
+local Sift = require(Plugin.Packages.Sift)
 
 local Enums = require(Plugin.Data.Enums)
 local Actions = require(Plugin.Actions)
@@ -35,7 +35,7 @@ local FRAMEWORK_ENUM_MAP = {
 	},
 }
 
-local DROPDOWN_OPTIONS = Llama.Dictionary.values(Llama.Dictionary.map(FRAMEWORK_ENUM_MAP, function(details, enumItem)
+local DROPDOWN_OPTIONS = Sift.Dictionary.values(Sift.Dictionary.map(FRAMEWORK_ENUM_MAP, function(details, enumItem)
 	return {
 		icon = details.icon,
 		label = details.label,

--- a/src/Components/JustifyFrame.lua
+++ b/src/Components/JustifyFrame.lua
@@ -1,7 +1,7 @@
 local Packages = script.Parent.Parent.Packages
 
 local Roact = require(Packages.Roact)
-local Llama = require(Packages.Llama)
+local Sift = require(Packages.Sift)
 local Hooks = require(Packages.Hooks)
 
 local e = Roact.createElement
@@ -25,7 +25,7 @@ local function JustifyFrame(props: JustifyFrameProps, hooks)
 			return 1
 		end
 
-		return max(Llama.Dictionary.count(props[Roact.Children]), 1)
+		return max(Sift.Dictionary.count(props[Roact.Children]), 1)
 	end, { props[Roact.Children] })
 
 	local childSize = hooks.useMemo(function()
@@ -41,7 +41,7 @@ local function JustifyFrame(props: JustifyFrameProps, hooks)
 			return {}
 		end
 
-		return Llama.Dictionary.map(props[Roact.Children], function(el)
+		return Sift.Dictionary.map(props[Roact.Children], function(el)
 			local prop = el.props["$justify"]
 
 			if type(prop) ~= "string" then
@@ -50,7 +50,7 @@ local function JustifyFrame(props: JustifyFrameProps, hooks)
 
 			return e(
 				el.component,
-				Llama.Dictionary.merge(el.props, {
+				Sift.Dictionary.merge(el.props, {
 					[prop] = childSize,
 				})
 			)

--- a/src/Components/Layout/ScrollColumn/ScrollButton.lua
+++ b/src/Components/Layout/ScrollColumn/ScrollButton.lua
@@ -3,7 +3,7 @@ local Packages = script.Parent.Parent.Parent.Parent.Packages
 local Roact = require(Packages.Roact)
 local Hooks = require(Packages.Hooks)
 local StudioTheme = require(Packages.StudioTheme)
-local Llama = require(Packages.Llama)
+local Sift = require(Packages.Sift)
 
 local Icon = require(script.Parent.Parent.Parent.Icon)
 
@@ -75,7 +75,7 @@ local function ScrollButton(props: ScrollButtonProps, hooks)
 	end
 
 	local iconProps = hooks.useMemo(function()
-		return Llama.Dictionary.merge(
+		return Sift.Dictionary.merge(
 			{
 				anchor = Vector2.new(0.5, 0.5),
 				position = UDim2.fromScale(0.5, 0.5),

--- a/src/Components/Pages/Home.lua
+++ b/src/Components/Pages/Home.lua
@@ -74,6 +74,12 @@ local function Page(_, hooks)
 			order = 15,
 		}),
 
+		instanceOmitHint = e(Text, {
+			text = "Instance-based properties (e.g. Adornee, PrimaryPart) will not be included in the output.",
+			textColour = theme:GetColor(Enum.StudioStyleGuideColor.DimmedText),
+			order = 16,
+		}),
+
 		activeSelection = e(Layout.Frame, {
 			order = 20,
 		}, {

--- a/src/Components/Pages/Settings/Inputs/CreateInput.lua
+++ b/src/Components/Pages/Settings/Inputs/CreateInput.lua
@@ -3,7 +3,7 @@ local Plugin = script.Parent.Parent.Parent.Parent.Parent
 local RoduxHooks = require(Plugin.Packages.RoduxHooks)
 local Roact = require(Plugin.Packages.Roact)
 local Hooks = require(Plugin.Packages.Hooks)
-local Llama = require(Plugin.Packages.Llama)
+local Sift = require(Plugin.Packages.Sift)
 
 local Actions = require(Plugin.Actions)
 
@@ -31,7 +31,7 @@ export type CreateInputOptions = {
 }
 
 return function(options: CreateInputOptions)
-	local DROPDOWN_OPTIONS = Llama.Dictionary.values(Llama.Dictionary.map(options.enumMap, function(details, enumItem)
+	local DROPDOWN_OPTIONS = Sift.Dictionary.values(Sift.Dictionary.map(options.enumMap, function(details, enumItem)
 		return {
 			label = details.label,
 			hint = details.hint,

--- a/src/Data/Config.lua
+++ b/src/Data/Config.lua
@@ -12,7 +12,7 @@ return {
 		dev = "rbxassetid://8906284857",
 	},
 
-	version = "2.2.3",
+	version = "2.2.4",
 	repo = "csqrl/codify-plugin",
 
 	authors = {

--- a/src/Lib/Codify/Frameworks/Fusion.lua
+++ b/src/Lib/Codify/Frameworks/Fusion.lua
@@ -42,9 +42,13 @@ local function FusionifyInstance(instance: Instance, options)
 				continue
 			end
 
-			options.PropIndent = #prop + 3
-
 			local value = Serialize.SerialiseProperty(instance, prop, options)
+
+			if value == nil then
+				continue
+			end
+
+			options.PropIndent = #prop + 3
 			snippet:CreateLine():Push(tab(), prop, " = ", value, ",")
 		end
 

--- a/src/Lib/Codify/Frameworks/Fusion.lua
+++ b/src/Lib/Codify/Frameworks/Fusion.lua
@@ -9,8 +9,12 @@ local function FusionifyInstance(instance: Instance, options)
 	local createMethod = options.CreateMethod or "New"
 	local snippet = Script.new()
 
-	local changedProps = select(2, Properties.GetChangedProperties(instance):await())
+	local success, changedProps = Properties.GetChangedProperties(instance):await()
 	local children = instance:GetChildren()
+
+	if not success then
+		error("Failed to get changed properties: " .. tostring(changedProps), 2)
+	end
 
 	local function tab()
 		return string.rep(options.TabCharacter, options.Indent)
@@ -24,13 +28,6 @@ local function FusionifyInstance(instance: Instance, options)
 
 	if options.NamingScheme == "All" or (options.NamingScheme == "Changed" and nameChanged) then
 		name = instance.Name
-
-		if options.LevelIdentifiers[name] ~= nil then
-			options.LevelIdentifiers[name] += 1
-			name ..= tostring(options.LevelIdentifiers[name])
-		else
-			options.LevelIdentifiers[name] = 0
-		end
 
 		snippet:CreateLine():Push(tab(), "Name = ", string.format("%q", name), ",")
 

--- a/src/Lib/Codify/Frameworks/Regular.lua
+++ b/src/Lib/Codify/Frameworks/Regular.lua
@@ -9,8 +9,12 @@ local fmt = string.format
 local function Regularify(instance: Instance, options)
 	local output = Script.new()
 
-	local changedProps = select(2, Properties.GetChangedProperties(instance):await())
+	local success, changedProps = Properties.GetChangedProperties(instance):await()
 	local children = instance:GetChildren()
+
+	if not success then
+		error("Failed to get changed properties: " .. tostring(changedProps), 2)
+	end
 
 	if not options._instanceNames then
 		options._instanceNames = {}
@@ -30,7 +34,7 @@ local function Regularify(instance: Instance, options)
 	local isNameChanged = table.find(changedProps, "Name")
 
 	if options.NamingScheme == "All" or (options.NamingScheme == "Changed" and isNameChanged) then
-		output:CreateLine():Push(fmt("%s.Name = %q", name, name))
+		output:CreateLine():Push(fmt("%s.Name = %q", name, instance.Name))
 	end
 
 	if #changedProps > 0 then

--- a/src/Lib/Codify/Frameworks/Regular.lua
+++ b/src/Lib/Codify/Frameworks/Regular.lua
@@ -43,10 +43,13 @@ local function Regularify(instance: Instance, options)
 				continue
 			end
 
-			options.PropIndent = #property + 3
-
 			local value = Serialise.SerialiseProperty(instance, property, options)
 
+			if value == nil then
+				continue
+			end
+
+			options.PropIndent = #property + 3
 			output:CreateLine():Push(fmt("%s.%s = %s", name, property, value))
 		end
 	end

--- a/src/Lib/Codify/Frameworks/Roact.lua
+++ b/src/Lib/Codify/Frameworks/Roact.lua
@@ -8,8 +8,12 @@ local function RoactifyInstance(instance: Instance, options)
 	local createMethod = options.CreateMethod or "Roact.createElement"
 	local snippet = Script.new()
 
-	local changedProps = select(2, Properties.GetChangedProperties(instance):await())
+	local success, changedProps = Properties.GetChangedProperties(instance):await()
 	local children = instance:GetChildren()
+
+	if not success then
+		error("Failed to get changed properties: " .. tostring(changedProps), 2)
+	end
 
 	local function tab()
 		return string.rep(options.TabCharacter, options.Indent)

--- a/src/Lib/Codify/Frameworks/Roact.lua
+++ b/src/Lib/Codify/Frameworks/Roact.lua
@@ -50,9 +50,13 @@ local function RoactifyInstance(instance: Instance, options)
 				continue
 			end
 
-			options.PropIndent = #prop + 3
-
 			local value = Serialize.SerialiseProperty(instance, prop, options)
+
+			if value == nil then
+				continue
+			end
+
+			options.PropIndent = #prop + 3
 			snippet:CreateLine():Push(tab(), prop, " = ", value, ",")
 		end
 

--- a/src/Lib/Codify/GetSafeName.lua
+++ b/src/Lib/Codify/GetSafeName.lua
@@ -1,16 +1,32 @@
+local split = string.split
+local match = string.match
 local lower = string.lower
-local find = string.find
 local gsub = string.gsub
 local sub = string.sub
+
+local DICTIONARY = split("abcdefghijklmnopqrstuvwxyz", "")
+
+local function CreateSafeName(name: string)
+	local firstChar = utf8.codepoint(sub(name, 1, 1))
+	local rest = gsub(sub(name, 2), "[^%w]", "_")
+
+	return DICTIONARY[firstChar % #DICTIONARY] .. rest
+end
 
 local function GetSafeName(instance: Instance)
 	local name = instance.Name
 
-	local firstChar = find(name, "^%a")
-	local prefix = lower(sub(name, firstChar, firstChar))
-	local suffix = sub(name, firstChar + 1)
+	local matchedSafeName = { match(name, "([%a_])(.+)") }
+	local safeName
 
-	local safeName = gsub(prefix .. suffix, "[^%w]", "_")
+	if #matchedSafeName == 2 then
+		safeName = lower(matchedSafeName[1]) .. matchedSafeName[2]
+		safeName = gsub(safeName, "[^%w_]", "_")
+	elseif match(name, "([%a_])") then
+		safeName = lower(name)
+	else
+		safeName = CreateSafeName(name)
+	end
 
 	return safeName
 end

--- a/src/Lib/Codify/Serialize.lua
+++ b/src/Lib/Codify/Serialize.lua
@@ -338,6 +338,8 @@ local function SerialiseProperty(instance: Instance, property: string, options: 
 		return SerialiseColorSequence(value, options)
 	elseif valueTypeOf == "NumberSequence" then
 		return SerialiseNumberSequence(value, options)
+	elseif valueTypeOf == "Instance" then
+		return nil
 	elseif valueType == "vector" or valueTypeOf:match("Vector%d") then
 		return FORMAT_MAP.VectorFormat.Full(value)
 	elseif valueTypeOf == "number" then

--- a/src/Lib/Codify/init.lua
+++ b/src/Lib/Codify/init.lua
@@ -1,4 +1,4 @@
-local Llama = require(script.Parent.Parent.Packages.Llama)
+local Sift = require(script.Parent.Parent.Packages.Sift)
 local Frameworks = require(script.Frameworks)
 export type CodifyOptions = {
 	Framework: string?,
@@ -43,7 +43,7 @@ local function CodifyInstance(instance: Instance, options: CodifyInstanceOptions
 end
 
 local function Codify(rootInstance: Instance, options: CodifyOptions?)
-	local config = Llama.Dictionary.merge(DEFAULT_OPTIONS, options or {}, {
+	local config = Sift.Dictionary.merge(DEFAULT_OPTIONS, options or {}, {
 		LevelIdentifiers = {},
 	}) :: CodifyInstanceOptions
 

--- a/src/Lib/HttpPromise.lua
+++ b/src/Lib/HttpPromise.lua
@@ -2,7 +2,7 @@ local HttpService = game:GetService("HttpService")
 local Plugin = script.Parent.Parent
 
 local Promise = require(Plugin.Packages.Promise)
-local Llama = require(Plugin.Packages.Llama)
+local Sift = require(Plugin.Packages.Sift)
 local String = require(script.Parent.String)
 
 export type RequestAsyncOptions = {
@@ -77,7 +77,7 @@ local function FetchCachedData(url: string): any?
 end
 
 local function ParseResponseHeaderCSV(header: string)
-	return Llama.List.reduce(header:split(","), function(reduction, value)
+	return Sift.Array.reduce(header:split(","), function(reduction, value)
 		local kvPair = value:split("=")
 
 		kvPair[1] = String.Trim(kvPair[1]):lower()
@@ -148,7 +148,7 @@ local function RequestAsync(url: string, options: RequestAsyncOptions?)
 		return Promise.resolve(cachedData)
 	end
 
-	local config = Llama.Dictionary.merge(DEFAULT_OPTIONS, options) :: RequestAsyncOptions
+	local config = Sift.Dictionary.merge(DEFAULT_OPTIONS, options) :: RequestAsyncOptions
 	local URL = ParseURL(url)
 
 	return PromptDomainApproval(url):andThen(function()

--- a/src/Lib/Properties.lua
+++ b/src/Lib/Properties.lua
@@ -102,6 +102,10 @@ function Properties.GetIgnoredPropertyNames(class: string)
 			end
 		end
 
+		for _, globalProperty in ipairs(IGNORED_PROPERTIES.Global) do
+			table.insert(ignoredProperties, globalProperty)
+		end
+
 		return Llama.List.flatten(ignoredProperties, 1)
 	end)
 end
@@ -153,10 +157,6 @@ function Properties.GetChangedProperties(instance: Instance)
 		local changedProps = {}
 
 		for _, property in ipairs(properties) do
-			if table.find(IGNORED_PROPERTIES.Global, property) then
-				continue
-			end
-
 			if newInstance[property] ~= instance[property] then
 				table.insert(changedProps, property)
 			end

--- a/src/Lib/Properties.lua
+++ b/src/Lib/Properties.lua
@@ -4,7 +4,7 @@ local Plugin = script.Parent.Parent
 
 local HttpPromise = require(Plugin.Lib.HttpPromise)
 local Promise = require(Plugin.Packages.Promise)
-local Llama = require(Plugin.Packages.Llama)
+local Sift = require(Plugin.Packages.Sift)
 
 local Properties = {}
 
@@ -67,7 +67,7 @@ function Properties.FetchAPIDump(hash: string)
 end
 
 local function FindClassEntry(dump, class: string)
-	local entryIndex = Llama.List.findWhere(dump.Classes, function(classEntry)
+	local entryIndex = Sift.Array.findWhere(dump.Classes, function(classEntry)
 		return classEntry.Name == class
 	end)
 
@@ -106,7 +106,7 @@ function Properties.GetIgnoredPropertyNames(class: string)
 			table.insert(ignoredProperties, globalProperty)
 		end
 
-		return Llama.List.flatten(ignoredProperties, 1)
+		return Sift.Array.flatten(ignoredProperties, 1)
 	end)
 end
 
@@ -116,7 +116,7 @@ function Properties.GetPropertyList(class: string)
 		local properties = {}
 
 		for _, ancestor in ipairs(ancestry) do
-			local propertyMembers = Llama.List.filter(ancestor.Members, function(member)
+			local propertyMembers = Sift.Array.filter(ancestor.Members, function(member)
 				if member.MemberType ~= "Property" then
 					return false
 				end

--- a/src/Reducer/Attribution.lua
+++ b/src/Reducer/Attribution.lua
@@ -1,4 +1,4 @@
-local Llama = require(script.Parent.Parent.Packages.Llama)
+local Sift = require(script.Parent.Parent.Packages.Sift)
 
 return function(state, action)
 	state = state or {
@@ -12,13 +12,13 @@ return function(state, action)
 			"SET_CONTRIBUTORS `action.payload` must be a table"
 		)
 
-		return Llama.Dictionary.merge(state, {
+		return Sift.Dictionary.merge(state, {
 			contributors = action.payload or {},
 		})
 	elseif action.type == "SET_AUTHORS" then
 		assert(type(action.payload) == "table" or action.payload == nil, "SET_AUTHORS `action.payload` must be a table")
 
-		return Llama.Dictionary.merge(state, {
+		return Sift.Dictionary.merge(state, {
 			authors = action.payload or {},
 		})
 	end

--- a/src/Reducer/PluginMetadata.lua
+++ b/src/Reducer/PluginMetadata.lua
@@ -1,5 +1,5 @@
 local Plugin = script.Parent.Parent
-local Llama = require(Plugin.Packages.Llama)
+local Sift = require(Plugin.Packages.Sift)
 
 local INIT_STATE = {
 	isDevMode = false,
@@ -10,7 +10,7 @@ return function(state, action)
 	state = state or INIT_STATE
 
 	if action.type == "SET_PLUGIN_METADATA" then
-		return Llama.Dictionary.merge(state, action.payload)
+		return Sift.Dictionary.merge(state, action.payload)
 	end
 
 	return state

--- a/src/Reducer/Snippet.lua
+++ b/src/Reducer/Snippet.lua
@@ -1,4 +1,4 @@
-local Llama = require(script.Parent.Parent.Packages.Llama)
+local Sift = require(script.Parent.Parent.Packages.Sift)
 
 return function(state, action)
 	state = state or {
@@ -10,7 +10,7 @@ return function(state, action)
 	if action.type == "SET_SNIPPET_PROCESSING" then
 		assert(type(action.payload) == "boolean", "SET_SNIPPET_PROCESSING `action.payload` must be a boolean")
 
-		return Llama.Dictionary.merge(state, {
+		return Sift.Dictionary.merge(state, {
 			processing = action.payload,
 		})
 	elseif action.type == "SET_SNIPPET_CONTENT" then
@@ -22,7 +22,7 @@ return function(state, action)
 			"SET_SNIPPET_CONTENT `action.payload.content` must be a string"
 		)
 
-		return Llama.Dictionary.merge(state, {
+		return Sift.Dictionary.merge(state, {
 			content = action.payload.content,
 			name = action.payload.name,
 		})

--- a/src/Reducer/UserSettings.lua
+++ b/src/Reducer/UserSettings.lua
@@ -1,6 +1,6 @@
 local Plugin = script.Parent.Parent
 
-local Llama = require(Plugin.Packages.Llama)
+local Sift = require(Plugin.Packages.Sift)
 local String = require(Plugin.Lib.String)
 local Enums = require(Plugin.Data.Enums)
 
@@ -19,7 +19,7 @@ local DEFAULT_SETTINGS = {
 }
 
 return function(state, action)
-	state = state or Llama.Dictionary.copy(DEFAULT_SETTINGS)
+	state = state or Sift.Dictionary.copy(DEFAULT_SETTINGS)
 
 	if action.type == "SET_SETTING" then
 		assert(type(action.payload) == "table", "SET_SETTING `payload` must be a table")
@@ -29,7 +29,7 @@ return function(state, action)
 			local newValue = String.Trim(action.payload.value)
 
 			if #newValue == 0 then
-				newValue = DEFAULT_SETTINGS[action.payload.key] or Llama.None
+				newValue = DEFAULT_SETTINGS[action.payload.key] or Sift.None
 			end
 
 			action.payload.value = newValue
@@ -39,10 +39,10 @@ return function(state, action)
 				action.payload.value = math.max(0, action.payload.value)
 			end
 		elseif action.payload.value == nil then
-			action.payload.value = Llama.None
+			action.payload.value = Sift.None
 		end
 
-		return Llama.Dictionary.merge(state, {
+		return Sift.Dictionary.merge(state, {
 			[action.payload.key] = action.payload.value,
 		})
 	end

--- a/src/Thunks/FetchAuthors.lua
+++ b/src/Thunks/FetchAuthors.lua
@@ -2,7 +2,7 @@ local Players = game:GetService("Players")
 local Plugin = script.Parent.Parent
 
 local Promise = require(Plugin.Packages.Promise)
-local Llama = require(Plugin.Packages.Llama)
+local Sift = require(Plugin.Packages.Sift)
 
 local Config = require(Plugin.Data.Config)
 local Actions = require(Plugin.Actions)
@@ -32,7 +32,7 @@ end
 
 local function FetchAuthors()
 	return function(store)
-		Promise.all(Llama.List.map(Config.authors, function(author)
+		Promise.all(Sift.Array.map(Config.authors, function(author)
 			return Promise.retryWithDelay(GetUsernameFromUserIdAsync, 3, 30, author.userId)
 		end))
 			:andThen(function(authors)

--- a/src/Thunks/FetchContributors.lua
+++ b/src/Thunks/FetchContributors.lua
@@ -1,14 +1,14 @@
 local Plugin = script.Parent.Parent
 
 local HttpPromise = require(Plugin.Lib.HttpPromise)
-local Llama = require(Plugin.Packages.Llama)
+local Sift = require(Plugin.Packages.Sift)
 local Actions = require(Plugin.Actions)
 
 local function FetchContributors(repo: string, authors: { string }?)
 	local repoOwner = repo:match("^[^/]+")
 
 	repoOwner = repoOwner and repoOwner:lower()
-	authors = Llama.List.map(authors or {}, function(author)
+	authors = Sift.Array.map(authors or {}, function(author)
 		return author:lower()
 	end)
 
@@ -19,7 +19,7 @@ local function FetchContributors(repo: string, authors: { string }?)
 					return a.contributions > b.contributions
 				end)
 
-				return Llama.List.reduce(data, function(reduction, user)
+				return Sift.Array.reduce(data, function(reduction, user)
 					local username = user.login or user.name
 
 					if username and not (username == repoOwner or table.find(authors, username)) then

--- a/wally.lock
+++ b/wally.lock
@@ -9,8 +9,13 @@ dependencies = []
 
 [[package]]
 name = "csqrl/codify-plugin"
-version = "2.2.2"
-dependencies = [["Highlighter", "boatbomber/highlighter@0.4.5"], ["Hooks", "kampfkarren/roact-hooks@0.3.0"], ["Llama", "freddylist/llama@1.1.1"], ["Promise", "evaera/promise@3.2.1"], ["Roact", "roblox/roact@1.4.2"], ["RoactRouter", "reselim/roact-router@1.0.3"], ["Rodux", "roblox/rodux@3.0.0"], ["RoduxHooks", "solarhorizon/rodux-hooks@0.2.1"], ["StudioPlugin", "csqrl/studio-plugin@1.0.1"], ["StudioTheme", "csqrl/studio-theme@1.0.2"]]
+version = "2.2.4"
+dependencies = [["Highlighter", "boatbomber/highlighter@0.4.5"], ["Hooks", "kampfkarren/roact-hooks@0.3.0"], ["Promise", "evaera/promise@4.0.0"], ["Roact", "roblox/roact@1.4.2"], ["RoactRouter", "reselim/roact-router@1.0.3"], ["Rodux", "roblox/rodux@3.0.0"], ["RoduxHooks", "solarhorizon/rodux-hooks@0.2.2"], ["Sift", "csqrl/sift@0.0.0"], ["StudioPlugin", "csqrl/studio-plugin@1.0.1"], ["StudioTheme", "csqrl/studio-theme@1.0.2"]]
+
+[[package]]
+name = "csqrl/sift"
+version = "0.0.0"
+dependencies = []
 
 [[package]]
 name = "csqrl/studio-plugin"
@@ -24,12 +29,7 @@ dependencies = [["Roact", "roblox/roact@1.4.2"]]
 
 [[package]]
 name = "evaera/promise"
-version = "3.2.1"
-dependencies = []
-
-[[package]]
-name = "freddylist/llama"
-version = "1.1.1"
+version = "4.0.0"
 dependencies = []
 
 [[package]]
@@ -54,5 +54,5 @@ dependencies = []
 
 [[package]]
 name = "solarhorizon/rodux-hooks"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [["Roact", "roblox/roact@1.4.2"]]

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "csqrl/codify-plugin"
 description = "Convert Instances to code; just like magic!"
-version = "2.2.3" # /src/Data/Config.lua
+version = "2.2.4" # /src/Data/Config.lua
 license = "MIT"
 authors = ["csqrl (https://csqrl.dev)", "boatbomber (https://www.boatbomber.com/)"]
 contributors = ["chriscerie"]
@@ -10,15 +10,12 @@ realm = "shared"
 
 [dependencies]
 Highlighter = "boatbomber/highlighter@=0.4.5"
-StudioPlugin = "csqrl/studio-plugin@^1.0.1"
-StudioTheme = "csqrl/studio-theme@^1.0.2"
-Promise = "evaera/promise@^3.2.1"
-Llama = "freddylist/llama@1.1.1"
-Hooks = "kampfkarren/roact-hooks@^0.3.0"
-RoactRouter = "reselim/roact-router@^1.0.3"
-Roact = "roblox/roact@^1.4.2"
-Rodux = "roblox/rodux@^3.0.0"
-RoduxHooks = "solarhorizon/rodux-hooks@^0.2.1"
-
-# [dev-dependencies]
-# TestEZ = "roblox/testez@^0.4.1"
+StudioPlugin = "csqrl/studio-plugin@=1.0.1"
+StudioTheme = "csqrl/studio-theme@=1.0.2"
+Promise = "evaera/promise@=4.0.0"
+Hooks = "kampfkarren/roact-hooks@=0.3.0"
+RoactRouter = "reselim/roact-router@=1.0.3"
+Roact = "roblox/roact@=1.4.2"
+Rodux = "roblox/rodux@=3.0.0"
+RoduxHooks = "solarhorizon/rodux-hooks@=0.2.2"
+Sift = "csqrl/sift@=0.0.0"


### PR DESCRIPTION
Summary of PR:

- **Add global ignores to `.GetIgnoredPropertyNames`**: Globally ignored properties are now included in the `.GetIgnoredPropertyNames` method of `Lib/Properties.lua`.
- **Fix unsafe name errors**: When generating a "safe name" for Instances whose names contain solely unsafe characters, Codify would error out. This closes [#21](https://github.com/csqrl/codify-plugin/issues/21) by mapping unsafe characters to a lowercase alphabet.
- **Omit Instance types**: If the property's value type is an Instance, it will be omitted from the resulting snippet.
 This does not close [#18](https://github.com/csqrl/codify-plugin/issues/18), but is a temporary fix for this. This will be reassessed later to allow the vanilla snippets to reference Instances if they are in scope.
- **Respect original name**: When generating snippets that include the `.Name` property of Instances, the name will now be the same as the original Instance's name, rather than being converted to camelCase.
- **Swap Llama for Sift**: [Llama](https://github.com/freddylist/llama)'s now deprecated. Switched to [Sift](https://github.com/csqrl/sift).
- **Instance Omission Feedback**: A message is now displayed on the home tab to inform users that Instance-based properties will be excluded from the output.