### PR TITLE
performance improvements

### DIFF
--- a/src/Components/Pages/Home.lua
+++ b/src/Components/Pages/Home.lua
@@ -104,14 +104,6 @@ local function Page(_, hooks)
 			}),
 		}),
 
-		largeInstance = targetInstance.large and e(Alert, {
-			label = snippet.processing and "This may take a while! Studio may lag or become unresponsive."
-				or "This Instance appears to have a lot of children! Can it be broken into smaller components?",
-			variant = Enum.MessageType.MessageWarning,
-			icon = "Warning",
-			order = 30,
-		}),
-
 		generateError = snippet.error and e(Alert, {
 			label = string.match(snippet.error, "Request timed out") and "Request timed out. Please try again."
 				or "An error occurred while generating the snippet. Please try again.",

--- a/src/Components/TextInput.lua
+++ b/src/Components/TextInput.lua
@@ -10,6 +10,7 @@ local Text = require(script.Parent.Text)
 
 local e = Roact.createElement
 
+local MAX_TEXTBOX_CHARS = 16300
 export type TextInputProps = {
 	autoSize: Enum.AutomaticSize?,
 	disabled: boolean?,
@@ -182,7 +183,7 @@ local function TextInput(props: TextInputProps, hooks)
 				BackgroundTransparency = 1,
 				Size = UDim2.new(1, 0, 0, height),
 				Font = props.font or styles.font.default,
-				Text = props.text,
+				Text = props.text and string.sub(props.text, 1, MAX_TEXTBOX_CHARS),
 				TextSize = props.textSize or styles.fontSize,
 				TextColor3 = colors.foreground,
 				TextXAlignment = Enum.TextXAlignment.Left,

--- a/src/Lib/Properties.lua
+++ b/src/Lib/Properties.lua
@@ -21,8 +21,9 @@ local IGNORED_PROPERTIES = {
 	},
 }
 
+local cachedDump
 function Properties.FetchDumpFromPluginCache()
-	local storedValue = plugin:GetSetting(PLUGIN_CACHE_KEY)
+	local storedValue = cachedDump or plugin:GetSetting(PLUGIN_CACHE_KEY)
 
 	if not storedValue then
 		return Promise.resolve()
@@ -32,6 +33,7 @@ function Properties.FetchDumpFromPluginCache()
 		return Promise.resolve()
 	end
 
+	cachedDump = storedValue
 	return Promise.resolve(storedValue)
 end
 
@@ -95,11 +97,13 @@ function Properties.FetchAPIDump(hash: string)
 			}
 		)
 			:andThen(function(apiDump)
-				plugin:SetSetting(PLUGIN_CACHE_KEY, {
+				local dump = {
 					Version = RobloxVersion,
 					VersionHash = hash,
 					Data = apiDump,
-				})
+				}
+				plugin:SetSetting(PLUGIN_CACHE_KEY, dump)
+				cachedDump = dump
 
 				return apiDump
 			end)
@@ -203,7 +207,6 @@ function Properties.GetChangedProperties(instance: Instance)
 		end
 
 		newInstance:Destroy()
-
 		return changedProps
 	end)
 end

--- a/src/Reducer/TargetInstance.lua
+++ b/src/Reducer/TargetInstance.lua
@@ -1,11 +1,3 @@
-local function IsLargeInstance(instance: Instance?): boolean
-	local ok, size = pcall(function()
-		return #instance:GetDescendants()
-	end)
-
-	return ok and size >= 20
-end
-
 return function(state, action)
 	state = state or {
 		instance = nil,
@@ -13,11 +5,8 @@ return function(state, action)
 	}
 
 	if action.type == "SET_TARGET_INSTANCE" then
-		local isLarge = IsLargeInstance(action.payload)
-
 		return {
 			instance = action.payload,
-			large = isLarge,
 		}
 	end
 

--- a/src/init.server.lua
+++ b/src/init.server.lua
@@ -7,6 +7,7 @@ local Rodux = require(script.Packages.Rodux)
 local UserSettingsManager = require(script.Lib.UserSettingsManager)
 local HighlighterManager = require(script.Lib.HighlighterManager)
 local SelectionManager = require(script.Lib.SelectionManager)
+local Properties = require(script.Lib.Properties)
 
 local AppComponent = require(script.Components.App)
 
@@ -26,6 +27,10 @@ end
 
 UserSettingsManager.new(plugin, store)
 HighlighterManager.new(plugin)
+
+-- Fetch the version early so we don't have to synchronize while converting
+-- the instances to code in parallel.
+Properties.FetchVersionWithFallback()
 
 do -- Handle Selection --
 	local selection = SelectionManager.new(plugin, {


### PR DESCRIPTION
The API Dump is now cached inside a variable rather than being constantly read from storage with GetSetting.

This provides enormous speed gains as we aren't reading from storage every time we need the API Dump and makes it possible to convert large instance trees into code without having it take a ridiculous amount of time.